### PR TITLE
spec: remove TM mark

### DIFF
--- a/package/yast2-samba-provision.changes
+++ b/package/yast2-samba-provision.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Nov  7 17:34:23 UTC 2018 - jengelh@inai.de
+
+- Remove TM mark.
+
+-------------------------------------------------------------------
 Wed Oct 31 17:17:35 UTC 2018 - Samuel Cabrero <scabrero@suse.de>
 
 - Fix required packages after samba-kdc renamed to samba-ad-dc

--- a/package/yast2-samba-provision.spec
+++ b/package/yast2-samba-provision.spec
@@ -43,7 +43,7 @@ Summary:	YaST2 - Samba AD DC provision
 
 %description
 This package contains the YaST2 component to configure samba as an Active
-Directory (TM) Domain Controller.
+Directory Domain Controller.
 
 %prep
 %setup -n %{name}-%{version}


### PR DESCRIPTION
Per the openSUSE guidelines, no (R) or (TM) is to be present in the %description block.